### PR TITLE
Fix unintended Nyan Cat highlighting on click

### DIFF
--- a/css/nyanFlyer.css
+++ b/css/nyanFlyer.css
@@ -52,6 +52,13 @@
     top: 50%;
     transform: translateY(-50%);
     z-index: 100;
+
+    -webkit-user-drag: none;
+    user-drag: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 .nyan-obstacle {
     position: absolute;


### PR DESCRIPTION
This patch prevents the browser’s default drag‑and‑select behavior on the Nyan Cat sprite in the “Nyan Flyer” mini‑game. Previously, every other click would turn the GIF grey/blue as if you were dragging it. Now, we explicitly disable user dragging and text/image selection via CSS vendor‑prefixed rules on the .nyan-cat class.

Closes #1